### PR TITLE
Fix missing class in cpp tensor documentation

### DIFF
--- a/docs/cpp/source/notes/tensor_basics.rst
+++ b/docs/cpp/source/notes/tensor_basics.rst
@@ -76,7 +76,7 @@ CUDA accessors
 .. code-block:: cpp
 
   __global__ void packed_accessor_kernel(
-      PackedTensorAccessor64<float, 2> foo,
+      torch::PackedTensorAccessor64<float, 2> foo,
       float* trace) {
     int i=threadIdx.x
     gpuAtomicAdd(trace, foo[i][i])


### PR DESCRIPTION
The given example in the documentation does not compile due to the missing `torch::`. It is correct in the tutorial about [writing a custom extension ](https://pytorch.org/tutorials/advanced/cpp_extension.html#writing-a-mixed-c-cuda-extension)